### PR TITLE
Adds Bullet logic and data, with some examples.

### DIFF
--- a/Assets/InputActions/player.inputactions
+++ b/Assets/InputActions/player.inputactions
@@ -31,6 +31,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "FireSecondary",
+                    "type": "Button",
+                    "id": "9a3e24cb-b4bf-44cd-a422-90f8a093400b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -251,6 +260,39 @@
                     "processors": "",
                     "groups": "XR",
                     "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fcf15f4c-98bc-45ec-8cd9-56730bd218c9",
+                    "path": "<Keyboard>/z",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ad0a1b2d-bd1d-4e51-ae5c-143778b8e89c",
+                    "path": "<Keyboard>/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "FireSecondary",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "99152114-b54a-48bb-8551-74425797fbba",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "FireSecondary",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,95 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5353368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5353369}
+  m_Layer: 0
+  m_Name: MainCannonLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5353369
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5353368}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.0321, y: 0.0508, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6121629550143812848}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &312982118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 312982119}
+  m_Layer: 0
+  m_Name: MainCannonRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &312982119
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312982118}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0301, y: 0.0508, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6121629550143812848}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1072053825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1072053826}
+  m_Layer: 0
+  m_Name: SecondaryCannon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1072053826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1072053825}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.0486, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6121629550143812848}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6121629550143812852
 GameObject:
   m_ObjectHideFlags: 0
@@ -13,9 +103,10 @@ GameObject:
   - component: {fileID: 6121629550143812850}
   - component: {fileID: 6121629550143812851}
   - component: {fileID: 6121629550143812815}
+  - component: {fileID: 6121629549981211826}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -30,7 +121,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 5353369}
+  - {fileID: 312982119}
+  - {fileID: 1072053826}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -131,7 +225,19 @@ MonoBehaviour:
     m_ActionId: 03f1d65f-70f3-4e7b-8809-6a4097d09b5e
     m_ActionName: Player/Look[/DualShock4GamepadHID/rightStick,/Mouse/delta,/Pen/delta]
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6121629549981211826}
+        m_TargetAssemblyTypeName: PlayerShots, Assembly-CSharp
+        m_MethodName: ShootPrimaryWeapon
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: 857ccb36-d4c4-48ab-8cd7-a454766a860b
     m_ActionName: Player/Fire[/DualShock4GamepadHID/rightTrigger,/Mouse/leftButton]
   - m_PersistentCalls:
@@ -174,6 +280,22 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: f4ba4687-8de6-431f-9a3b-0e6295eeda29
     m_ActionName: UI/TrackedDeviceOrientation
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6121629549981211826}
+        m_TargetAssemblyTypeName: PlayerShots, Assembly-CSharp
+        m_MethodName: ShootSecondaryWeapon
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 9a3e24cb-b4bf-44cd-a422-90f8a093400b
+    m_ActionName: Player/FireSecondary[/Keyboard/x,/Mouse/rightButton]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player
@@ -213,3 +335,22 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
+--- !u!114 &6121629549981211826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6121629550143812852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f683edcc12b9be44f88b60d2cbcbaa9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  primaryBullet: {fileID: 5067348146002385777, guid: 72563c703af283e4eaf6b7a66fe2de63, type: 3}
+  secondaryBullet: {fileID: 5067348146002385777, guid: 2f03fee3271537c4dbcc498e1f1240fd, type: 3}
+  primaryWeapon:
+  - {fileID: 5353369}
+  - {fileID: 312982119}
+  secondaryWeapon:
+  - {fileID: 1072053826}

--- a/Assets/Prefabs/SineBullet.prefab
+++ b/Assets/Prefabs/SineBullet.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5067348146002385777
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5067348146002385791}
+  - component: {fileID: 5067348146002385790}
+  - component: {fileID: 3467785494428099482}
+  - component: {fileID: 3693371536464878027}
+  m_Layer: 0
+  m_Name: SineBullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5067348146002385791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5067348146002385790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 572a7fa0b3f4d5f49b5207a78b7af5d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bullet: {fileID: 11400000, guid: d221aceba2a84134d959121607bdf17d, type: 2}
+--- !u!212 &3467785494428099482
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 0, g: 0.7231324, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &3693371536464878027
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 0.0001
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/SineBullet.prefab.meta
+++ b/Assets/Prefabs/SineBullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2f03fee3271537c4dbcc498e1f1240fd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/StraightBullet.prefab
+++ b/Assets/Prefabs/StraightBullet.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5067348146002385777
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5067348146002385791}
+  - component: {fileID: 5067348146002385790}
+  - component: {fileID: 3467785494428099482}
+  - component: {fileID: 3693371536464878027}
+  m_Layer: 0
+  m_Name: StraightBullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5067348146002385791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5067348146002385790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 572a7fa0b3f4d5f49b5207a78b7af5d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bullet: {fileID: 11400000, guid: 168d03302c6babe4db068bf87ab2d2a5, type: 2}
+--- !u!212 &3467785494428099482
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 0, g: 0.7231324, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &3693371536464878027
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067348146002385777}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 0.0001
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/StraightBullet.prefab.meta
+++ b/Assets/Prefabs/StraightBullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72563c703af283e4eaf6b7a66fe2de63
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SOData/SineBullet.asset
+++ b/Assets/SOData/SineBullet.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd05cdaac437bcc409132899a5d7f263, type: 3}
+  m_Name: SineBullet
+  m_EditorClassIdentifier: 
+  bulletName: Sine
+  xSpeed: 1
+  ySpeed: 1
+  bulletMovement: {fileID: 11400000, guid: db1fe8c476b95724b89f19b1852d152a, type: 2}

--- a/Assets/SOData/SineBullet.asset.meta
+++ b/Assets/SOData/SineBullet.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d221aceba2a84134d959121607bdf17d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SOData/SineBulletBehavior.asset
+++ b/Assets/SOData/SineBulletBehavior.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83fd1d49ceebbbe40b4f5ad911fa8aa0, type: 3}
+  m_Name: SineBulletBehavior
+  m_EditorClassIdentifier: 

--- a/Assets/SOData/SineBulletBehavior.asset.meta
+++ b/Assets/SOData/SineBulletBehavior.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db1fe8c476b95724b89f19b1852d152a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SOData/StraightBulletBehavior.asset
+++ b/Assets/SOData/StraightBulletBehavior.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25d7a3f69dbfdb54e9f2db49cbbef4e1, type: 3}
+  m_Name: StraightBulletBehavior
+  m_EditorClassIdentifier: 

--- a/Assets/SOData/StraightBulletBehavior.asset.meta
+++ b/Assets/SOData/StraightBulletBehavior.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f6942880d26c04448c74db54d2271ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SOData/VerticalBullet.asset
+++ b/Assets/SOData/VerticalBullet.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd05cdaac437bcc409132899a5d7f263, type: 3}
+  m_Name: VerticalBullet
+  m_EditorClassIdentifier: 
+  bulletName: Vertical
+  xSpeed: 0
+  ySpeed: 1
+  bulletMovement: {fileID: 11400000, guid: 9f6942880d26c04448c74db54d2271ed, type: 2}

--- a/Assets/SOData/VerticalBullet.asset.meta
+++ b/Assets/SOData/VerticalBullet.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 168d03302c6babe4db068bf87ab2d2a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Events.meta
+++ b/Assets/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6aca3cbdd64466242b7116de0819e07d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Events/BulletHitEventArgs.cs
+++ b/Assets/Scripts/Events/BulletHitEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEngine;
+using Weapons;
+
+namespace Events
+{
+    public delegate void BulletHitEventHandler(object sender, BulletHitEventArgs eventArgs);
+    public class BulletHitEventArgs : EventArgs
+    {
+        public BulletSo Bullet { get; set; }
+
+        public BulletHitEventArgs(BulletSo bullet)
+        {
+            Bullet = bullet;
+        }
+    }
+}

--- a/Assets/Scripts/Events/BulletHitEventArgs.cs.meta
+++ b/Assets/Scripts/Events/BulletHitEventArgs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44c1fe0349009624899eb000e7f6724b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerShots.cs
+++ b/Assets/Scripts/Player/PlayerShots.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using Weapons;
+
+namespace Player
+{
+    public class PlayerShots : MonoBehaviour
+    {
+        [SerializeField] private GameObject primaryBullet;
+        [SerializeField] private GameObject secondaryBullet;
+        [SerializeField] private Transform[] primaryWeapon;
+        [SerializeField] private Transform[] secondaryWeapon;
+
+        public void ShootPrimaryWeapon(InputAction.CallbackContext context)
+        {
+            Shoot(PrimaryBullet, PrimaryWeapon);
+        }
+    
+        public void ShootSecondaryWeapon(InputAction.CallbackContext context)
+        {
+            Shoot(SecondaryBullet, SecondaryWeapon);
+        }
+
+        private static void Shoot(GameObject bulletSo, Transform[] spawnPoints)
+        {
+            foreach (var spawnPoint in spawnPoints)
+            {
+                Instantiate(bulletSo, spawnPoint);
+            }
+        }
+        
+        public GameObject PrimaryBullet => primaryBullet;
+        public GameObject SecondaryBullet => secondaryBullet;
+        public Transform[] PrimaryWeapon => primaryWeapon;
+        public Transform[] SecondaryWeapon => secondaryWeapon;
+    }
+}

--- a/Assets/Scripts/Player/PlayerShots.cs.meta
+++ b/Assets/Scripts/Player/PlayerShots.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f683edcc12b9be44f88b60d2cbcbaa9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/AbstractBulletMovement.cs
+++ b/Assets/Scripts/Weapons/AbstractBulletMovement.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace Weapons
+{
+    public abstract class AbstractBulletMovement : ScriptableObject
+    {
+        public abstract IEnumerator Move(Vector2 speed, BulletController bulletController);
+    }
+}

--- a/Assets/Scripts/Weapons/AbstractBulletMovement.cs.meta
+++ b/Assets/Scripts/Weapons/AbstractBulletMovement.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 19f6a5007e869a24998344abe66bc54e
+guid: 6f14333b8b63cb04bbe97864945e49cb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Weapons/BulletController.cs
+++ b/Assets/Scripts/Weapons/BulletController.cs
@@ -1,0 +1,48 @@
+using System;
+using Events;
+using UnityEngine;
+
+namespace Weapons
+{
+    public class BulletController : MonoBehaviour
+    {
+        [SerializeField] private BulletSo bullet;
+        public static event BulletHitEventHandler EnemyHitEventHandler;
+        public static event BulletHitEventHandler PlayerHitEventHandler;
+
+        public Rigidbody2D RigidBody { get; set; }
+
+        private void Start()
+        {
+            RigidBody = GetComponent<Rigidbody2D>();
+            StartCoroutine(Bullet.BulletMovement.Move(new Vector2(Bullet.XSpeed, Bullet.YSpeed), this));
+        }
+
+        private void OnTriggerEnter2D(Collider2D col)
+        {
+            if (CompareTag("PlayerBullet"))
+            {
+                if (!col.gameObject.CompareTag("Enemy")) return;
+                EnemyHitEventHandler?.Invoke(null, new BulletHitEventArgs(Bullet));
+                DestroyBullet();
+            }
+            else if (CompareTag("EnemyBullet"))
+            {
+                if (!col.gameObject.CompareTag("Player")) return;
+                PlayerHitEventHandler?.Invoke(null, new BulletHitEventArgs(Bullet));
+                DestroyBullet();
+            }
+        }
+
+        private static void DestroyBullet()
+        {
+            //TODO play sfx with a Coroutine and kill after it finishes
+        }
+        
+        public BulletSo Bullet
+        {
+            get => bullet;
+            set => bullet = value;
+        }
+    }
+}

--- a/Assets/Scripts/Weapons/BulletController.cs.meta
+++ b/Assets/Scripts/Weapons/BulletController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 572a7fa0b3f4d5f49b5207a78b7af5d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/BulletSo.cs
+++ b/Assets/Scripts/Weapons/BulletSo.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Weapons
+{
+    [CreateAssetMenu(fileName = "Bullets", menuName = "Scriptable Objects/Bullet", order = 0)]
+    public class BulletSo : ScriptableObject
+    {
+        [SerializeField] private string bulletName;
+        [SerializeField] private float xSpeed;
+        [SerializeField] private float ySpeed;
+        [SerializeField] private AbstractBulletMovement bulletMovement;
+
+        public string Name
+        {
+            get => bulletName;
+            set => bulletName = value;
+        }
+
+        public float XSpeed
+        {
+            get => xSpeed;
+            set => xSpeed = value;
+        }
+
+        public float YSpeed
+        {
+            get => ySpeed;
+            set => ySpeed = value;
+        }
+        
+        public AbstractBulletMovement BulletMovement
+        {
+            get => bulletMovement;
+            set => bulletMovement = value;
+        }
+    }
+}

--- a/Assets/Scripts/Weapons/BulletSo.cs.meta
+++ b/Assets/Scripts/Weapons/BulletSo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd05cdaac437bcc409132899a5d7f263
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/SineBullet.cs
+++ b/Assets/Scripts/Weapons/SineBullet.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Weapons
+{
+    [CreateAssetMenu(fileName = "BulletBehavior", menuName = "Scriptable Objects/Sine Bullet", order = 0)]
+    public class SineBullet : AbstractBulletMovement
+    {
+        private float _angle;
+        public override IEnumerator Move(Vector2 speed, BulletController bulletController)
+        {
+            var bulletTransformPosition = bulletController.transform.position;
+            var directionX = bulletTransformPosition.x + SinMovement();
+            var directionY = 1;
+
+            var moveDirection = new Vector3(directionX, directionY, 0f);
+            var direction = (moveDirection - bulletTransformPosition).normalized;
+
+            _angle =(_angle+10f)%360f;
+
+            bulletController.RigidBody.velocity = direction*speed;
+            
+            yield return new WaitForSeconds(0.1f);
+        }
+
+        private float SinMovement()
+        {
+            return Mathf.Sin(((_angle + 180f) * Mathf.PI) / 180f);
+        }
+        private float CosMovement()
+        {
+            return Mathf.Cos(((_angle + 180f) * Mathf.PI) / 180f);
+        }
+    }
+}

--- a/Assets/Scripts/Weapons/SineBullet.cs.meta
+++ b/Assets/Scripts/Weapons/SineBullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83fd1d49ceebbbe40b4f5ad911fa8aa0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/StraightBullet.cs
+++ b/Assets/Scripts/Weapons/StraightBullet.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Weapons
+{
+    [CreateAssetMenu(fileName = "BulletBehavior", menuName = "Scriptable Objects/Straight Bullet", order = 0)]
+    public class StraightBullet : AbstractBulletMovement
+    {
+        public override IEnumerator Move(Vector2 speed, BulletController bulletController)
+        {
+            bulletController.RigidBody.velocity = speed;
+            yield return null;
+        }
+    }
+}

--- a/Assets/Scripts/Weapons/StraightBullet.cs.meta
+++ b/Assets/Scripts/Weapons/StraightBullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25d7a3f69dbfdb54e9f2db49cbbef4e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapons/WeaponSO.cs
+++ b/Assets/Scripts/Weapons/WeaponSO.cs
@@ -1,8 +1,0 @@
-using UnityEngine;
-
-namespace Weapons
-{
-    public class WeaponSO : ScriptableObject
-    {
-    }
-}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,10 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Enemy
+  - PlayerBullet
+  - EnemyBullet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Fix #5 
Adds Bullet SO to contain bullet data and bullet behavior SO, to hold the AI behind each bullet with an abstract class behind it so it can be plug-and-play. Also creates a Bullet Controller to handle collision, loading and destroying stuff. Adds empty events to handle damage to both player and enemy, TODO: finish the event handling and link it later with the UI and Health Controller system for both player and enemy. Creates a Vertical and Sinusoid bullets with no gameplay balancing yet.